### PR TITLE
Store credentials sign up in database

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,19 +6,9 @@ container:
   cpu: 4
   memory: 16G
   kvm: true
-  services:
-    - name: firestore-emulator
-      image: gcr.io/cloud-devrel-public-resources/firestore-emulator:latest
-      command:
-        - sh
-        - '-c'
-        - 'firebase setup:emulators:firestore && firebase emulators:start --only firestore --host 0.0.0.0'
-      privileged: true
-      ports:
-        - "8080:8080"
 
 install_script:
-  - gcloud components install cloud-firestore-emulator
+  -  curl -sL firebase.tools | bash
 
 check_android_task:
   name: Run Android tests
@@ -57,6 +47,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
+    - 'firebase emulators:start --only firestore'
     - ./gradlew check connectedCheck
     
   report_codeclimate_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,6 @@ container:
   memory: 16G
   kvm: true
 
-
-
 check_android_task:
   name: Run Android tests
   install_emulator_script:
@@ -50,7 +48,7 @@ check_android_task:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script: |
     chmod +x firebase_bin
-    ./firebase_bin emulators:exec --project palfinder-sdp './gradlew check connectedCheck'
+    ./firebase_bin emulators:exec --project sdp-orkest-firebase --only firestore './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,9 +48,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script: |
-    firebase emulators:start --only firestore
-    curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
-    ./gradlew check connectedCheck
+    firebase emulators:start --only firestore './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,9 +57,9 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    export FIRESTORE_EMULATOR_HOST=localhost:8080
-    gcloud firestore emulators clear-emulators --host-port=$FIRESTORE_EMULATOR_HOST
-    ./gradlew check connectedCheck
+    - export FIRESTORE_EMULATOR_HOST=localhost:8080
+    - gcloud firestore emulators clear-emulators --host-port=$FIRESTORE_EMULATOR_HOST
+    - ./gradlew check connectedCheck
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,8 @@ container:
   memory: 16G
   kvm: true
 
+
+
 check_android_task:
   name: Run Android tests
   install_emulator_script:
@@ -26,7 +28,7 @@ check_android_task:
       -camera-back none
     
   install_script:
-    curl -Lo ./firebase_bin https://firebase.tools/bin/linux/latest
+    curl -sL firebase.tools | bash
   assemble_instrumented_tests_script: |
     chmod +x gradlew
     ./gradlew assembleDebugAndroidTest
@@ -45,9 +47,10 @@ check_android_task:
     
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
-  check_script:
-    chmod +x firebase_bin
-    ./firebase_bin emulators:exec --only firestore './gradlew check connectedCheck'
+  check_script: |
+    firebase emulators:start --only firestore
+    curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
+    ./gradlew check connectedCheck
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,7 +57,6 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    - curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
     - ./gradlew check connectedCheck
     
   report_codeclimate_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,7 @@ container:
   memory: 16G
   kvm: true
 
-install_script:
-  -  curl -sL firebase.tools | bash
+
 
 check_android_task:
   name: Run Android tests
@@ -28,6 +27,8 @@ check_android_task:
       -no-window
       -camera-back none
     
+  install_script:
+    curl -sL firebase.tools | bash
   assemble_instrumented_tests_script: |
     chmod +x gradlew
     ./gradlew assembleDebugAndroidTest
@@ -47,8 +48,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    - 'firebase emulators:start --only firestore'
-    - ./gradlew check connectedCheck
+    firebase emulators:start --only firestore --host-port=localhost:8080 './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,9 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    firebase emulators:start --only firestore --host-port=localhost:8080 './gradlew check connectedCheck'
+    firebase emulators:start --only firestore --host=localhost --port=8080
+    curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
+    ./gradlew check connectedCheck
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,9 +48,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    firebase emulators:start --only firestore
-    curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
-    ./gradlew check connectedCheck
+    firebase emulators:start --only firestore './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,19 @@ container:
   cpu: 4
   memory: 16G
   kvm: true
+  services:
+    - name: firestore-emulator
+      image: gcr.io/cloud-devrel-public-resources/firestore-emulator:latest
+      command:
+        - sh
+        - '-c'
+        - 'firebase setup:emulators:firestore && firebase emulators:start --only firestore --host 0.0.0.0'
+      privileged: true
+      ports:
+        - "8080:8080"
+
+install_script:
+  - gcloud components install cloud-firestore-emulator
 
 check_android_task:
   name: Run Android tests
@@ -24,6 +37,7 @@ check_android_task:
       -no-snapshot
       -no-window
       -camera-back none
+    
   assemble_instrumented_tests_script: |
     chmod +x gradlew
     ./gradlew assembleDebugAndroidTest
@@ -43,6 +57,8 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
+    export FIRESTORE_EMULATOR_HOST=localhost:8080
+    gcloud firestore emulators clear-emulators --host-port=$FIRESTORE_EMULATOR_HOST
     ./gradlew check connectedCheck
     
   report_codeclimate_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,7 @@ container:
 
 install_script:
   - gcloud components install cloud-firestore-emulator
+  - gcloud components install beta
 
 check_android_task:
   name: Run Android tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,6 @@ container:
 
 install_script:
   - gcloud components install cloud-firestore-emulator
-  - gcloud components install beta
 
 check_android_task:
   name: Run Android tests
@@ -58,8 +57,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    - export FIRESTORE_EMULATOR_HOST=localhost:8080
-    - gcloud firestore emulators clear-emulators --host-port=$FIRESTORE_EMULATOR_HOST
+    - curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
     - ./gradlew check connectedCheck
     
   report_codeclimate_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,6 @@ container:
   memory: 16G
   kvm: true
 
-
-
 check_android_task:
   name: Run Android tests
   install_emulator_script:
@@ -28,7 +26,7 @@ check_android_task:
       -camera-back none
     
   install_script:
-    curl -sL firebase.tools | bash
+    curl -Lo ./firebase_bin https://firebase.tools/bin/linux/latest
   assemble_instrumented_tests_script: |
     chmod +x gradlew
     ./gradlew assembleDebugAndroidTest
@@ -48,7 +46,8 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    firebase emulators:start --only firestore './gradlew check connectedCheck'
+    chmod +x firebase_bin
+    ./firebase_bin emulators:exec --only firestore './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script:
-    firebase emulators:start --only firestore --host=localhost --port=8080
+    firebase emulators:start --only firestore
     curl -v -X DELETE "http://localhost:8080/emulator/v1/projects/sdp-orkest-firebase/databases/(default)/documents"
     ./gradlew check connectedCheck
     

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,9 @@ check_android_task:
       -no-window
       -camera-back none
     
-  install_script:
-    curl -sL firebase.tools | bash
+  download_firebase_emulator_script: |
+    curl -Lo ./firebase_bin https://firebase.tools/bin/linux/latest
+
   assemble_instrumented_tests_script: |
     chmod +x gradlew
     ./gradlew assembleDebugAndroidTest
@@ -48,7 +49,8 @@ check_android_task:
   screen_record_background_script:
     for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
   check_script: |
-    firebase emulators:start --only firestore './gradlew check connectedCheck'
+    chmod +x firebase_bin
+    ./firebase_bin emulators:exec --project palfinder-sdp './gradlew check connectedCheck'
     
   report_codeclimate_script: |
     export JACOCO_SOURCE_PATH=app/src/main/java/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Orkest/.idea/gradle.xml
 .idea/codeStyles/Project.xml
 .idea/workspace.xml
 local.properties
+.idea/workspace.xml
+.idea/inspectionProfiles/Project_Default.xml

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Orkest/.idea/gradle.xml
 local.properties
 .idea/workspace.xml
 .idea/inspectionProfiles/Project_Default.xml
+.idea/workspace.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.0'
+
     testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/app/src/androidTest/java/com/github/orkest/View/auth/SignUpFormTest.kt
+++ b/app/src/androidTest/java/com/github/orkest/View/auth/SignUpFormTest.kt
@@ -1,11 +1,16 @@
-package com.github.orkest
+package com.github.orkest.View.auth
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.compose.rememberNavController
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import com.github.orkest.Model.Providers
+import com.github.orkest.View.MainActivity
 import com.github.orkest.View.auth.SignUpForm
 import com.github.orkest.ViewModel.auth.AuthViewModel
+import com.github.orkest.ViewModel.auth.MockAuthViewModel
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -15,11 +20,11 @@ class SignUpFormTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private lateinit var viewModel: AuthViewModel
+    private lateinit var viewModel: MockAuthViewModel
     @Before
     fun setup(){
         // Start the app
-        viewModel = AuthViewModel()
+        viewModel = MockAuthViewModel()
         composeTestRule.setContent {
             SignUpForm(navController = rememberNavController(), viewModel)
         }
@@ -103,7 +108,26 @@ class SignUpFormTest {
         composeTestRule.onNodeWithText("Spotify").performClick()
         composeTestRule.onNodeWithText("Service Provider: Spotify").assertIsDisplayed()
         assert(viewModel.getProvider() == Providers.SPOTIFY)
+    }
 
+    @Test
+    fun alreadyExistingUserNameDisplaysError(){
+        composeTestRule.onNodeWithText("Username")
+            .performTextInput(MockAuthViewModel.EXISTING_USER)
 
+        composeTestRule.onNodeWithText("Create Profile").performClick()
+
+        composeTestRule.onNodeWithText("This username already exists!").assertIsDisplayed()
+    }
+
+    @Test
+    fun validUsernameLaunchesMain(){
+        Intents.init()
+        composeTestRule.onNodeWithText("Username")
+            .performTextInput(MockAuthViewModel.VALID_USER)
+
+        composeTestRule.onNodeWithText("Create Profile").performClick()
+        intended((hasComponent(MainActivity::class.java.name)))
+        Intents.release()
     }
 }

--- a/app/src/androidTest/java/com/github/orkest/ViewModel/auth/AuthViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/orkest/ViewModel/auth/AuthViewModelTest.kt
@@ -1,0 +1,71 @@
+package com.github.orkest.ViewModel.auth
+
+import androidx.compose.ui.text.input.TextFieldValue
+import com.github.orkest.Model.Providers
+import com.google.firebase.firestore.ktx.firestoreSettings
+import org.junit.Before
+
+import org.junit.BeforeClass
+
+import org.junit.Test
+
+
+// Before Launching these tests, you must start the emulator in the command line, using:
+// gcloud beta emulators firestore start --host-port=localhost:8080
+// To run these tests twice, you must clear the database or restart it before running them again
+class AuthViewModelTest {
+
+    companion object {
+        private lateinit var auth: AuthViewModel
+
+        private const val name = "Steve123"
+        private const val bio = "bio"
+        private val provider = Providers.DEEZER
+
+        @BeforeClass
+        @JvmStatic
+        fun setupEmulator() {
+            auth = AuthViewModel()
+            auth.db.useEmulator("10.0.2.2", 8080)
+            auth.db.firestoreSettings = firestoreSettings {
+                isPersistenceEnabled = false
+            }
+        }
+    }
+
+    @Before
+    fun setup(){
+        auth.updateUsername(TextFieldValue(name))
+        auth.updateBio(TextFieldValue(bio))
+        auth.updateProvider(provider)
+    }
+
+    @Test
+    fun usernameUpdatesCorrectly() {
+        assert(auth.getUsername().text == name)
+    }
+
+    @Test
+    fun bioUpdatesCorrectly() {
+        assert(auth.getBio().text == bio)
+    }
+
+    @Test
+    fun providerUpdatesCorrectly() {
+        assert(auth.getProvider() == provider)
+    }
+
+    @Test
+    fun createValidUserReturnsTrue() {
+        auth.updateUsername(TextFieldValue("Valid"))
+        assert(auth.createUser().get() == true)
+    }
+
+    @Test
+    fun createInvalidUserReturnsFalse() {
+        auth.updateUsername(TextFieldValue("Invalid"))
+        assert(auth.createUser().get() == true)
+        //Adding 2 times the same user should return false
+        assert(auth.createUser().get() == false)
+    }
+}

--- a/app/src/androidTest/java/com/github/orkest/ViewModel/auth/MockAuthViewModel.kt
+++ b/app/src/androidTest/java/com/github/orkest/ViewModel/auth/MockAuthViewModel.kt
@@ -1,0 +1,27 @@
+package com.github.orkest.ViewModel.auth
+
+import java.util.concurrent.CompletableFuture
+
+class MockAuthViewModel : AuthViewModel() {
+
+    companion object {
+        val EXISTING_USER = "exists"
+        val VALID_USER = "valid"
+    }
+
+
+    @Override
+    override fun createUser(): CompletableFuture<Boolean>{
+        val future = CompletableFuture<Boolean>()
+        val username = getUsername().text
+
+        if (username == EXISTING_USER)
+             future.complete(false)
+
+        if (username == VALID_USER)
+            future.complete((true))
+
+        return future
+    }
+
+}

--- a/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
+++ b/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
@@ -108,7 +108,15 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
 
                 Box(modifier = Modifier.padding(40.dp, 0.dp, 40.dp, 0.dp)) {
                     Button(
-                        onClick = {},
+                        onClick = { viewModel.createUser()
+                            .whenComplete { result, exception ->
+                                if(result) {
+                                    //Launches intent to the main Activity
+                                } else {
+                                    //Displays error
+                                }
+                            }
+                        },
                         shape = RoundedCornerShape(50.dp),
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
+++ b/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
@@ -1,6 +1,8 @@
 package com.github.orkest.View.auth
 
 import android.annotation.SuppressLint
+import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,12 +13,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.github.orkest.Model.Providers
+import com.github.orkest.View.MainActivity
 import com.github.orkest.View.theme.White
 import com.github.orkest.ViewModel.auth.AuthViewModel
 
@@ -26,6 +30,18 @@ import com.github.orkest.ViewModel.auth.AuthViewModel
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
+
+    // Value storing the context, used later to launch the Main Activity
+    val context = LocalContext.current
+
+    // Value used for the dropDown menu selecting the providers
+    val expanded = remember { mutableStateOf(false) }
+
+    // Value used to display an error message if the username already exists
+    val userExists = remember {
+        mutableStateOf(false)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -37,10 +53,7 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-
-                val expanded = remember { mutableStateOf(false) }
-
-
+                //Title of the page
                 Text(
                     text = "Create Your Profile",
                     style = TextStyle(fontSize = 40.sp, fontFamily = FontFamily.Cursive)
@@ -48,14 +61,22 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
 
                 Spacer(modifier = Modifier.height(15.dp))
 
+                // Field to enter the username
                 TextField(
                     label = { Text(text = "Username") },
                     value = viewModel.getUsername(),
                     onValueChange = { viewModel.updateUsername(it) }
                 )
+                //Displays an error when the username already exists
+                AnimatedVisibility(visible = userExists.value){
+                    Text(text = "This username already exists!",
+                        color = Color.Red,
+                        modifier = Modifier.width(280.dp))
+                }
 
                 Spacer(modifier = Modifier.height(15.dp))
 
+                // Field to enter the bio description
                 TextField(
                     modifier = Modifier.width(280.dp),
                     label = { Text(text = "Profile Description") },
@@ -65,9 +86,8 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
 
                 Spacer(modifier = Modifier.height(15.dp))
 
+                // Box with button to choose the service provider
                 Box {
-
-
                     Button(
                         colors= ButtonDefaults.buttonColors(backgroundColor = Color(217,217,217)),
                         onClick = {expanded.value = true},
@@ -106,14 +126,19 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
                 Spacer(modifier = Modifier.height(15.dp))
 
 
+                //Button to confirm choices
                 Box(modifier = Modifier.padding(40.dp, 0.dp, 40.dp, 0.dp)) {
                     Button(
                         onClick = { viewModel.createUser()
-                            .whenComplete { result, exception ->
+                            .whenComplete { result, _ ->
                                 if(result) {
                                     //Launches intent to the main Activity
+                                    val intent = Intent(context, MainActivity::class.java)
+                                    // TODO: Next see if needed to send the user's data as an Extra
+                                    context.startActivity(intent)
                                 } else {
                                     //Displays error
+                                    userExists.value = true
                                 }
                             }
                         },
@@ -128,7 +153,6 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
                     }
                 }
             }
-
         })
 }
 

--- a/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
+++ b/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
@@ -43,10 +43,12 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
     }
 
     Scaffold(
+        //Creates the top bar
         topBar = {
             TopAppBar(
                 title = { Text(text = "Create Your Profile") },
             )},
+        
         content = {
             Column(
                 modifier = Modifier.padding(20.dp),

--- a/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
+++ b/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
@@ -25,8 +25,8 @@ import com.github.orkest.View.theme.White
 import com.github.orkest.ViewModel.auth.AuthViewModel
 
 
-// Needs to be initialized in the main activity and called as a callback function
-// after the google authentication sign up returns
+// Needs to be initialized in the auth activity and called as a callback function
+// after the google authentication sign in returns
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
@@ -48,7 +48,7 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
             TopAppBar(
                 title = { Text(text = "Create Your Profile") },
             )},
-        
+
         content = {
             Column(
                 modifier = Modifier.padding(20.dp),

--- a/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
+++ b/app/src/main/java/com/github/orkest/View/auth/SignUpForm.kt
@@ -86,7 +86,7 @@ fun SignUpForm(navController: NavController, viewModel: AuthViewModel) {
 
                 Spacer(modifier = Modifier.height(15.dp))
 
-                // Box with button to choose the service provider
+                // Box with button to choose the service provider from a dropDownMenu
                 Box {
                     Button(
                         colors= ButtonDefaults.buttonColors(backgroundColor = Color(217,217,217)),

--- a/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
@@ -77,16 +77,17 @@ open class AuthViewModel: ViewModel() {
         //Updates the user's credentials
         updateUser()
 
-        //Computes the path to store the user in : users-firstLetter of its username
+        // Computes the path to store the user in : user/user-firstLetter/users
+        // user-firstletter is a document containing a subcollection which contains the users's documents
         val firstLetter = username.value.text[0].uppercase()
-        val path = "users-$firstLetter"
+        val path = "user/user-$firstLetter/users"
 
         val future = CompletableFuture<Boolean>()
 
         //Checks if the database already contains a user with the same username
         db.collection(path)
             .document(user.username).get()
-            .addOnSuccessListener { //TODO: Handle failure too
+            .addOnSuccessListener {
                 if (it.data != null) {
                     println(it)
                     future.complete(false)
@@ -96,6 +97,7 @@ open class AuthViewModel: ViewModel() {
                         .addOnSuccessListener { future.complete(true) }
                 }
             }
+            //Propagates the exception in case of another exception
             .addOnFailureListener{
                 future.completeExceptionally(it)
             }
@@ -113,7 +115,6 @@ open class AuthViewModel: ViewModel() {
         user.serviceProvider = selectedProvider.value.value
     }
 
-    //TODO: handle concurrency
     /**
      * Adds the newly created user to the database
      */

--- a/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
@@ -77,9 +77,9 @@ open class AuthViewModel: ViewModel() {
         //Updates the user's credentials
         updateUser()
 
-        //Computes the path to store the user in : Users/firstLetter of its username
-        val firstLetter = username.value.text[0]
-        val path = "Users/$firstLetter"
+        //Computes the path to store the user in : users-firstLetter of its username
+        val firstLetter = username.value.text[0].uppercase()
+        val path = "users-$firstLetter"
 
         val future = CompletableFuture<Boolean>()
 
@@ -87,13 +87,17 @@ open class AuthViewModel: ViewModel() {
         db.collection(path)
             .document(user.username).get()
             .addOnSuccessListener { //TODO: Handle failure too
-                if (it != null) {
+                if (it.data != null) {
+                    println(it)
                     future.complete(false)
                 } else {
                     //If no user with the same username was found, add the user to the database
                     pushUser(path)
                         .addOnSuccessListener { future.complete(true) }
                 }
+            }
+            .addOnFailureListener{
+                future.completeExceptionally(it)
             }
 
         return future

--- a/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/github/orkest/ViewModel/auth/AuthViewModel.kt
@@ -11,7 +11,7 @@ import com.google.firebase.ktx.Firebase
 import java.util.concurrent.CompletableFuture
 
 
-class AuthViewModel: ViewModel() {
+open class AuthViewModel: ViewModel() {
 
     var db = Firebase.firestore
 
@@ -72,13 +72,10 @@ class AuthViewModel: ViewModel() {
      * True if the user has been successfully added to the database,
      * False if the username already exists in the database
      */
-    fun createUser(): CompletableFuture<Boolean> {
+    open fun createUser(): CompletableFuture<Boolean> {
 
         //Updates the user's credentials
-        user.username = username.value.text
-        user.profile.username = user.username
-        user.profile.bio = bio.value.text
-        user.serviceProvider = selectedProvider.value.value
+        updateUser()
 
         //Computes the path to store the user in : Users/firstLetter of its username
         val firstLetter = username.value.text[0]
@@ -102,6 +99,16 @@ class AuthViewModel: ViewModel() {
         return future
     }
 
+    /**
+     * Updates the user's credentials after validation
+     */
+    private fun updateUser(){
+        user.username = username.value.text
+        user.profile.username = user.username
+        user.profile.bio = bio.value.text
+        user.serviceProvider = selectedProvider.value.value
+    }
+
     //TODO: handle concurrency
     /**
      * Adds the newly created user to the database
@@ -110,8 +117,4 @@ class AuthViewModel: ViewModel() {
         return db.collection(path).document(user.username)
             .set(user)
     }
-
-
-
-
 }


### PR DESCRIPTION
Updated the viewModel associated to the Sign Up activity such that the infos related to the newly created user are stored in the database.

It checks if a username already exists in the database and displays an error, otherwise, it send the user to the main activity

Finally, to test the UI, I created a mockAuthView that simulates a database returning false for a used username and true for a valid one.

The ViewModel was tested using the firestore emulator which was also integrated to the CI. The emulator doesn't automatically resets its values between each test, so we must make sure to clear it in our tests if desired.

This PR closes #30 