### PR TITLE
Fixed the fetching of recent-posts: it should be >= not just >

### DIFF
--- a/app/src/androidTest/java/com/github/orkest/ViewModel/feed/PostViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/orkest/ViewModel/feed/PostViewModelTest.kt
@@ -3,7 +3,9 @@ package com.github.orkest.ViewModel.feed
 import androidx.compose.ui.text.input.TextFieldValue
 import com.github.orkest.data.Constants
 import com.github.orkest.data.Comment
+import com.github.orkest.domain.FireStoreDatabaseAPI
 import com.github.orkest.ui.feed.PostViewModel
+import com.google.firebase.firestore.ktx.firestoreSettings
 import org.junit.BeforeClass
 import org.junit.Test
 import java.time.LocalDateTime

--- a/app/src/main/java/com/github/orkest/domain/FireStoreDatabaseAPI.kt
+++ b/app/src/main/java/com/github/orkest/domain/FireStoreDatabaseAPI.kt
@@ -284,7 +284,7 @@ class FireStoreDatabaseAPI {
         val posts = db.collectionGroup("posts")
         posts.whereEqualTo(FieldPath.of("date", "year"), year)
             .whereEqualTo(FieldPath.of("date", "month"), month)
-            .whereGreaterThan(FieldPath.of("date", "dayOfMonth"), day)
+            .whereGreaterThanOrEqualTo(FieldPath.of("date", "dayOfMonth"), day)
             .get().addOnSuccessListener {
                 // Get all posts documents as a list of posts objects
                 val list: MutableList<Post> = it.toObjects(Post::class.java)


### PR DESCRIPTION
Fixed a bug discovered by the test suite that was blocking merging :
The bug was due to the use of greaterThan query instead of a GreaterThanOrEqual query for the recent posts, since we are the 1st of May, the comparison against posts greaterThanOrEqual to 1st may returned an empty list.

The bug is fixed now