### PR TITLE
fix crash when sharing music offline

### DIFF
--- a/app/src/main/java/com/github/orkest/domain/FireStoreDatabaseAPI.kt
+++ b/app/src/main/java/com/github/orkest/domain/FireStoreDatabaseAPI.kt
@@ -27,14 +27,16 @@ open class FireStoreDatabaseAPI {
 
     companion object{
         val db = Firebase.firestore
+        fun isOnline(context: Context): Boolean {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val network = connectivityManager.activeNetwork ?: return false
+            val networkCapabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        }
     }
 
-    fun isOnline(context: Context): Boolean {
-        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val network = connectivityManager.activeNetwork ?: return false
-        val networkCapabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
-        return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-    }
+
+
 
     //============================USER OPERATIONS==========================================
 

--- a/app/src/main/java/com/github/orkest/ui/sharing/PlaylistActivity.kt
+++ b/app/src/main/java/com/github/orkest/ui/sharing/PlaylistActivity.kt
@@ -81,7 +81,6 @@ class PlaylistActivity() : ComponentActivity() {
         }
     }
 
-
     @Composable
     private fun SetContent(){
         // A surface container using the 'background' color from the theme

--- a/app/src/main/java/com/github/orkest/ui/sharing/PlaylistViewModel.kt
+++ b/app/src/main/java/com/github/orkest/ui/sharing/PlaylistViewModel.kt
@@ -21,7 +21,7 @@ open class PlaylistViewModel(private val songDao: AppDao.Companion.SongDao) : Vi
     // method to fetch songs from database
     fun fetchSongs(sender: String, receiver: String, context: Context) : CompletableFuture<List<Song>>  {
         // check internet connection
-        return if (dbAPI.isOnline(context)){
+        return if (FireStoreDatabaseAPI.isOnline(context)){
             dbAPI.fetchSharedSongsFromDataBase(receiver, sender)
         }else{
             // get songs from cache
@@ -37,7 +37,7 @@ open class PlaylistViewModel(private val songDao: AppDao.Companion.SongDao) : Vi
     // method to store songs in database
     fun storeSong(song: Song, sender: String, receiver: String, context: Context) {
         CompletableFuture.runAsync {
-            if (dbAPI.isOnline(context)){
+            if (FireStoreDatabaseAPI.isOnline(context)){
                 // cache the new song in the database
                 this.songDao.insertAll(AppEntities.Companion.SongEntity(
                     // random id

--- a/app/src/main/java/com/github/orkest/ui/sharing/SharingActivity.kt
+++ b/app/src/main/java/com/github/orkest/ui/sharing/SharingActivity.kt
@@ -1,8 +1,10 @@
 package com.github.orkest.ui.sharing
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
+import android.os.Looper
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -25,9 +27,10 @@ import com.github.orkest.data.Providers
 import com.github.orkest.domain.Authorization.Companion.getLoginActivityTokenIntent
 import com.github.orkest.domain.Authorization.Companion.requestUserAuthorization
 import com.github.orkest.domain.FireStoreDatabaseAPI
+import com.github.orkest.ui.MainActivity
 import com.github.orkest.ui.search.SearchUserView
-import com.github.orkest.ui.theme.OrkestTheme
 import com.github.orkest.ui.search.SearchViewModel
+import com.github.orkest.ui.theme.OrkestTheme
 import com.spotify.sdk.android.auth.AuthorizationClient
 import com.spotify.sdk.android.auth.AuthorizationResponse
 import okhttp3.*
@@ -68,6 +71,29 @@ class SharingComposeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
+
+        // ----------------------------------------------------------------------------------------
+        // Check if device connected to the internet
+        if(!FireStoreDatabaseAPI.isOnline(this)){
+            Log.d("Debug", "No internet connection")
+            // alert the user that the device is not connected to the internet
+            val alertDialogBuilder = AlertDialog.Builder(this)
+            alertDialogBuilder.setTitle("No internet connection")
+            alertDialogBuilder.setMessage("Please connect to the internet to share songs with your friends")
+            alertDialogBuilder.setPositiveButton("OK") { _, _ ->
+                finish()
+            }
+            alertDialogBuilder.show()
+            // wait for the user to press OK
+            try {
+                Looper.loop()
+            } catch (_: RuntimeException) { }
+            
+            // kill this activity
+            return
+
+        }
+
 
         // Get the song name from the intent ----------------- Intent from Orkest -----------------
         if (intent.hasExtra(Constants.SONG_NAME)) {


### PR DESCRIPTION
This PR fixes the crash of the application when a user attempts to share a song while offline.

I inserted a dialog box that asks the user to connect to the internet. Clicking on "OK" terminates the sharing activity.

Modifications made to the rest of the codebase:
- isOnline() method was moved to a companion object in the FirestoreDatabaseAPI in order to make it static and use it elsewhere.